### PR TITLE
mmx-ep: install "mmx-ep" binary with executable flag

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -169,7 +169,7 @@ ep_config.h: ep_config.h.in
 
 install:
 	install -d $(DESTDIR)$(PREFIX)/sbin
-	install -m 644 $(EXECUTABLE) $(DESTDIR)$(PREFIX)/sbin
+	install -m 0755 $(EXECUTABLE) $(DESTDIR)$(PREFIX)/sbin
 
 clean:
 	rm -f *.o $(EXECUTABLE)


### PR DESCRIPTION
Fix installation "mmx-ep" with 0755 instead of 644 mode
That mistake appeared on split mmx-ep OpenWrt feed and sources